### PR TITLE
Modify npm-publish.yaml to allow manual push to "next" tag on npm

### DIFF
--- a/.github/workflows/npm-publish.yaml
+++ b/.github/workflows/npm-publish.yaml
@@ -1,22 +1,41 @@
-
 # This workflow will run tests using node and then publish a package to GitHub Packages when a release is created
 # For more information see: https://help.github.com/actions/language-and-framework-guides/publishing-nodejs-packages
 
 name: Node.js Package
 
 on:
+  workflow_dispatch:
+    inputs:
+      tag:
+        description: 'The tag to publish to: latest | next'
+        required: false
+        default: 'latest'
   release:
-    types: [published]
+    types: [ published ]
 
 jobs:
   publish-npm:
     runs-on: ubuntu-latest
     steps:
+      - name: Check Tag Name
+        if: ${{ github.event.inputs.tag != 'latest' && github.event.inputs.tag != 'next' }}
+        run: |
+          echo 'Only the tags "latest" or "next" are supported. You entered "${{ github.event.inputs.tag }}"'
+          exit 1
       - uses: actions/checkout@v2
       - uses: actions/setup-node@v1
         with:
           node-version: 14.x
-          registry-url: https://registry.npmjs.org/
-      - run: npm publish
-        env:
-          NODE_AUTH_TOKEN: ${{secrets.ADOBE_BOT_NPM_TOKEN}}
+      - uses: actions/cache@v2
+        id: npm-cache
+        with:
+          path: '**/node_modules'
+          key: ${{ runner.os }}-modules-${{ hashFiles('**/package-lock.json') }}
+      - name: Install dependencies
+        if: steps.npm-cache.outputs.cache-hit != 'true'
+        run: npm ci
+      - run: npm test
+      - uses: JS-DevTools/npm-publish@v1
+        with:
+          token: ${{ secrets.ADOBE_BOT_NPM_TOKEN }}
+          tag: ${{ github.event.inputs.tag }}


### PR DESCRIPTION
## Description

<!--- Describe your changes in detail -->

## Motivation and Context

Allows us to put experimental features on a `next` tag on NPM.

## How Has This Been Tested?

1. `npm test'
2. Follows the same logic as https://github.com/adobe/reactor-turbine/blob/master/.github/workflows/npm-publish.yaml

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [x] Repo maintenance

## Do these changes need to be coordinated with changes in other repositories?

no

## Checklist:

<!--- Go over all the following points and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [x] I have signed the [Adobe Open Source CLA](http://opensource.adobe.com/cla.html).
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.
- [x] All new and existing tests passed.
