### PR TITLE
iOS core v3 support

### DIFF
--- a/schemas/extension-package-mobile.json
+++ b/schemas/extension-package-mobile.json
@@ -67,7 +67,7 @@
         ]
       },
       "minItems": 1,
-      "maxItems": 2
+      "maxItems": 3
     },
     "events": {
       "type": "array",
@@ -163,7 +163,6 @@
               "$ref": "#/definitions/podVersion"
             }
           },
-          "additionalProperties": false,
           "required": [
             "name",
             "headerName",
@@ -194,7 +193,6 @@
               "$ref": "#/definitions/podVersion"
             }
           },
-          "additionalProperties": false,
           "required": [
             "name",
             "headerNames",
@@ -214,7 +212,7 @@
     },
     "iosHeaderName": {
       "type": "string",
-      "pattern": "^[a-zA-Z_][a-zA-Z\\d_]*\\/?[a-zA-Z_][a-zA-Z\\d_]*\\.[a-zA-Z]$"
+      "pattern": "^[a-zA-Z_][a-zA-Z\\d_]*\\/?[a-zA-Z_][a-zA-Z\\d_]*(\\.[a-zA-Z])?$"
     },
     "iosInterface": {
       "type": "string",

--- a/schemas/extension-package-mobile.json
+++ b/schemas/extension-package-mobile.json
@@ -56,7 +56,7 @@
     },
     "repositories": {
       "type": "array",
-      "additionalItems": {
+      "items": {
         "oneOf": [
           {
             "$ref": "#/definitions/maven"
@@ -161,8 +161,12 @@
             },
             "version": {
               "$ref": "#/definitions/podVersion"
+            },
+            "core": {
+              "$ref": "#/definitions/podVersion"
             }
           },
+          "additionalProperties": false,
           "required": [
             "name",
             "headerName",
@@ -191,8 +195,12 @@
             },
             "version": {
               "$ref": "#/definitions/podVersion"
+            },
+            "core": {
+              "$ref": "#/definitions/podVersion"
             }
           },
+          "additionalProperties": false,
           "required": [
             "name",
             "headerNames",

--- a/test/example-extension-mobile.json
+++ b/test/example-extension-mobile.json
@@ -22,6 +22,17 @@
         "ACPAnalytics"
       ],
       "version": "1.0.0"
+    },
+    {
+      "name": "ACPAnalytics",
+      "headerNames": [
+        "AdobeAnalytics"
+      ],
+      "interfaces": [
+        "ACPAnalytics"
+      ],
+      "version": "1.0.0",
+      "core": "v3"
     }
   ],
   "platform": "mobile",

--- a/test/example-extension-mobile.json
+++ b/test/example-extension-mobile.json
@@ -32,7 +32,7 @@
         "ACPAnalytics"
       ],
       "version": "1.0.0",
-      "core": "v3"
+      "core": "3.0.0"
     }
   ],
   "platform": "mobile",


### PR DESCRIPTION
## Description

Allow for `additionalProperties` for the `cocoapods` schema definition so extension developers can target an iOS core version. Also, extensions can now have more than one 'cocoapod` repository. One for <= 2.x support. One for >= 3.x support.

## Motivation and Context

The Mobile SDK team is preparing a v3 core release, and with it comes breaking API changes.
This new additional schema property will be used by the install instructions UI to determine if the extension is supported by the v3 iOS core extension.

https://jira.corp.adobe.com/browse/MOB-14139

## How Has This Been Tested?

An additional cocoapod repository was added:

```
    {
      "name": "ACPAnalytics",
      "headerNames": [
        "AdobeAnalytics"
      ],
      "interfaces": [
        "ACPAnalytics"
      ],
      "version": "1.0.0",
      "core": "v3"
    }
```

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Do these changes need to be released within a particular timeframe?

Yes. TBD.

## Would there be any problems if we released these changes immediately?

Yes. Install instructions inside the Launch UI need to be updated first.

## Do you foresee yourself proposing other known changes soon?

Yes. Which is why a specific additional property was not defined. So we're opting with an open `additionalProperties`

## Do these changes need to be coordinated with changes in other repositories?

Yes. The Launch UI

## Checklist:

<!--- Go over all the following points and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [x] I have signed the [Adobe Open Source CLA](http://opensource.adobe.com/cla.html).
- [x] My code follows the code style of this project.
- [x] My change requires a change to the documentation.
- [x] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [x] I have added tests to cover my changes.
- [x] All new and existing tests passed.
