### PR TITLE
add cocoapods properties for obj-c interface names

### DIFF
--- a/schemas/extension-package-mobile.json
+++ b/schemas/extension-package-mobile.json
@@ -159,6 +159,9 @@
             "interface": {
               "$ref": "#/definitions/iosInterface"
             },
+            "objcInterface": {
+              "$ref": "#/definitions/iosInterface"
+            },
             "version": {
               "$ref": "#/definitions/podVersion"
             },
@@ -187,6 +190,13 @@
               "minItems": 1
             },
             "interfaces": {
+              "type": "array",
+              "items": {
+                "$ref": "#/definitions/iosInterface"
+              },
+              "minItems": 1
+            },
+            "objcInterfaces": {
               "type": "array",
               "items": {
                 "$ref": "#/definitions/iosInterface"

--- a/schemas/extension-package-mobile.json
+++ b/schemas/extension-package-mobile.json
@@ -159,7 +159,7 @@
             "interface": {
               "$ref": "#/definitions/iosInterface"
             },
-            "interfaceObjc": {
+            "objcInterface": {
               "$ref": "#/definitions/iosInterface"
             },
             "version": {
@@ -196,7 +196,7 @@
               },
               "minItems": 1
             },
-            "interfacesObjc": {
+            "objcInterfaces": {
               "type": "array",
               "items": {
                 "$ref": "#/definitions/iosInterface"

--- a/schemas/extension-package-mobile.json
+++ b/schemas/extension-package-mobile.json
@@ -159,13 +159,13 @@
             "interface": {
               "$ref": "#/definitions/iosInterface"
             },
-            "objcInterface": {
+            "interfaceObjc": {
               "$ref": "#/definitions/iosInterface"
             },
             "version": {
               "$ref": "#/definitions/podVersion"
             },
-            "core": {
+            "coreVersion": {
               "$ref": "#/definitions/podVersion"
             }
           },
@@ -196,7 +196,7 @@
               },
               "minItems": 1
             },
-            "objcInterfaces": {
+            "interfacesObjc": {
               "type": "array",
               "items": {
                 "$ref": "#/definitions/iosInterface"
@@ -206,7 +206,7 @@
             "version": {
               "$ref": "#/definitions/podVersion"
             },
-            "core": {
+            "coreVersion": {
               "$ref": "#/definitions/podVersion"
             }
           },

--- a/schemas/extension-package-mobile.json
+++ b/schemas/extension-package-mobile.json
@@ -56,7 +56,7 @@
     },
     "repositories": {
       "type": "array",
-      "additionalItems": {
+      "items": {
         "oneOf": [
           {
             "$ref": "#/definitions/maven"
@@ -67,7 +67,7 @@
         ]
       },
       "minItems": 1,
-      "maxItems": 2
+      "maxItems": 3
     },
     "events": {
       "type": "array",
@@ -161,6 +161,9 @@
             },
             "version": {
               "$ref": "#/definitions/podVersion"
+            },
+            "core": {
+              "$ref": "#/definitions/podVersion"
             }
           },
           "additionalProperties": false,
@@ -192,6 +195,9 @@
             },
             "version": {
               "$ref": "#/definitions/podVersion"
+            },
+            "core": {
+              "$ref": "#/definitions/podVersion"
             }
           },
           "additionalProperties": false,
@@ -214,7 +220,7 @@
     },
     "iosHeaderName": {
       "type": "string",
-      "pattern": "^[a-zA-Z_][a-zA-Z\\d_]*\\/?[a-zA-Z_][a-zA-Z\\d_]*\\.[a-zA-Z]$"
+      "pattern": "^[a-zA-Z_][a-zA-Z\\d_]*\\/?[a-zA-Z_][a-zA-Z\\d_]*(\\.[a-zA-Z])?$"
     },
     "iosInterface": {
       "type": "string",

--- a/schemas/extension-package-mobile.json
+++ b/schemas/extension-package-mobile.json
@@ -67,7 +67,7 @@
         ]
       },
       "minItems": 1,
-      "maxItems": 3
+      "maxItems": 2
     },
     "events": {
       "type": "array",

--- a/test/example-extension-mobile.json
+++ b/test/example-extension-mobile.json
@@ -31,11 +31,11 @@
       "interfaces": [
         "Analytics"
       ],
-      "objcInterfaces": [
+      "interfacesObjc": [
         "AEPMobileAnalytics"
       ],
       "version": "3.0.0",
-      "core": "3.0.0"
+      "coreVersion": "3.0.0"
     }
   ],
   "platform": "mobile",

--- a/test/example-extension-mobile.json
+++ b/test/example-extension-mobile.json
@@ -31,7 +31,7 @@
       "interfaces": [
         "Analytics"
       ],
-      "interfacesObjc": [
+      "objcInterfaces": [
         "AEPMobileAnalytics"
       ],
       "version": "3.0.0",

--- a/test/example-extension-mobile.json
+++ b/test/example-extension-mobile.json
@@ -22,6 +22,17 @@
         "ACPAnalytics"
       ],
       "version": "1.0.0"
+    },
+    {
+      "name": "ACPAnalytics",
+      "headerNames": [
+        "AdobeAnalytics"
+      ],
+      "interfaces": [
+        "ACPAnalytics"
+      ],
+      "version": "1.0.0",
+      "core": "3.0.0"
     }
   ],
   "platform": "mobile",

--- a/test/example-extension-mobile.json
+++ b/test/example-extension-mobile.json
@@ -24,14 +24,17 @@
       "version": "1.0.0"
     },
     {
-      "name": "ACPAnalytics",
+      "name": "AEPAnalytics",
       "headerNames": [
-        "AdobeAnalytics"
+        "AEPAnalytics"
       ],
       "interfaces": [
-        "ACPAnalytics"
+        "Analytics"
       ],
-      "version": "1.0.0",
+      "objcInterfaces": [
+        "AEPMobileAnalytics"
+      ],
+      "version": "3.0.0",
       "core": "3.0.0"
     }
   ],

--- a/test/example-extension-mobile.json
+++ b/test/example-extension-mobile.json
@@ -14,16 +14,6 @@
       "artifact": "com.adobe.marketing.mobile:analytics:1.0.0"
     },
     {
-      "name": "ACPAnalytics",
-      "headerNames": [
-        "AdobeAnalytics.h"
-      ],
-      "interfaces": [
-        "ACPAnalytics"
-      ],
-      "version": "1.0.0"
-    },
-    {
       "name": "AEPAnalytics",
       "headerNames": [
         "AEPAnalytics"


### PR DESCRIPTION
## Description

Added new property objcInterfaces for the cocoapods schema definition so extension developers can specify the Objective-C interface name(s) for install instructions for iOS core>=3.x.

## Motivation and Context

In the new v3 core released by the Mobile SDK team, unlike core v2, the interface name(s) for Swift and Objective-C are different. This new schema property will be used by the install instructions UI to display the correct code to register extensions for Objective-C mobile applications which use the v3 core.

## How Has This Been Tested?

An additional property was added for cocoapod repository

``` {
      "name": "AEPAnalytics",
      "headerNames": [
        "AEPAnalytics"
      ],
      "interfaces": [
        "Analytics"
      ],
      "objcInterfaces": [
        "AEPMobileAnalytics"
      ],
      "version": "3.0.0",
      "core": "3.0.0"
    }
```

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Do these changes need to be released within a particular timeframe?

Yes, TBD.

## Would there be any problems if we released these changes immediately?

Yes. Install instructions inside the Launch UI need to be updated first.

## Do you foresee yourself proposing other known changes soon?

No.

## Do these changes need to be coordinated with changes in other repositories?

Yes. The Launch UI.

## Checklist:

<!--- Go over all the following points and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [x] I have signed the [Adobe Open Source CLA](http://opensource.adobe.com/cla.html).
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [x] I have added tests to cover my changes.
- [x] All new and existing tests passed.
