### PR TITLE
Allow string and numbers for default value of a preprocessing variable.

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@adobe/reactor-turbine-schemas",
-  "version": "10.7.2-beta.2",
+  "version": "10.8.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@adobe/reactor-turbine-schemas",
-      "version": "10.7.2-beta.2",
+      "version": "10.8.0",
       "license": "Apache-2.0",
       "devDependencies": {
         "ajv": "^8.17.1",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@adobe/reactor-turbine-schemas",
-  "version": "10.7.2-beta.2",
+  "version": "10.8.0",
   "description": "A collection of schema used for validation of JSON objects within Tags.",
   "repository": {
     "type": "git",

--- a/schemas/extension-package-web.json
+++ b/schemas/extension-package-web.json
@@ -346,7 +346,13 @@
       "properties": {
         "key": { "type": "string", "minLength": 1 },
         "path": { "type": "string", "minLength": 1 },
-        "default": { "type": "boolean" }
+        "default": {
+          "oneOf": [
+            { "type": "boolean" },
+            { "type": "number" },
+            { "type": "string" }
+          ]
+        }
       },
       "additionalProperties": false,
       "required": ["key", "path", "default"]


### PR DESCRIPTION
## Description

We need to allow string and numbers as values for preprocessing variables.

## Motivation and Context

A new feature in Web SDK extension needs to be added. It will allow users to use the extension with an already existing alloy instance on the page.

## How Has This Been Tested?

I tested the new schema with various values in a json schema validator too.

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Do these changes need to be released within a particular timeframe?

As soon as the release schedule permits.

## Would there be any problems if we released these changes immediately?

No.

## Do you foresee yourself proposing other known changes soon?

No.

## Do these changes need to be coordinated with changes in other repositories?

It would be nice to use the new version in the sandbox tool too.

## Checklist:

<!--- Go over all the following points and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [x] I have signed the [Adobe Open Source CLA](http://opensource.adobe.com/cla.html).
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.
