### PR TITLE
Adding this line to .npmrc made github actions expect a parameter cal…

### DIFF
--- a/.npmrc
+++ b/.npmrc
@@ -1,1 +1,1 @@
-//registry.npmjs.org/:_authToken=${NPM_TOKEN}
+engine-strict=true


### PR DESCRIPTION
…led _authToken, which broke github actions

## Description

<!--- Describe your changes in detail -->

Removes 

`//registry.npmjs.org/:_authToken=${NPM_TOKEN}`

from .npmrc

## Motivation and Context

<!--- Why is this change required? What problem does it solve? -->

This line breaks Github Actions deployments

## How Has This Been Tested?

<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

I was able to manually run a push of Turbine Schemas to the `next` tag

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Do these changes need to be released within a particular timeframe?

<!--- Are these changes time-sensitive? Is there an expected release date? -->

## Would there be any problems if we released these changes immediately?

<!--- Should we wait for some reason? -->

## Do you foresee yourself proposing other known changes soon?

<!-- Waiting for all known changes to be merged before deploying can reduce overhead. -->

## Do these changes need to be coordinated with changes in other repositories?

<!--- Would there be any problem if these changes were released before/after related changes in other repositories? -->

## Checklist:

<!--- Go over all the following points and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [x] I have signed the [Adobe Open Source CLA](http://opensource.adobe.com/cla.html).
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.
- [x] All new and existing tests passed.
